### PR TITLE
fix `{{ runner.os }}` being interpreted as jinja2 code

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/style.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/style.yml
@@ -12,6 +12,7 @@ on:
       - '{{cookiecutter.module_name}}/locale/**'
       - '{{cookiecutter.module_name}}/static/**'
 
+{% raw %}
 jobs:
   isort:
     name: isort
@@ -128,3 +129,4 @@ jobs:
       - name: Check package
         run: twine check dist/*
         working-directory: .
+{% endraw %}


### PR DESCRIPTION
This can be reproduced in an empty virtualenv:

```bash
➜  pip install cookiecutter
Collecting cookiecutter
  Using cached cookiecutter-1.7.3-py2.py3-none-any.whl (34 kB)
[...]
➜  cookiecutter https://github.com/pretalx/pretalx-plugin-cookiecutter
repo_name [pretalx-superplugin]: test
repo_url [GitHub repository URL]: test
module_name [pretalx_superplugin]: test
human_name [The pretalx super plugin]: test
author_name [Your name]: test
author_email [Your email]: test
year [Current year]: test
short_description [Short description]: test
Unable to create file '.github/workflows/style.yml'
Error message: 'runner' is undefined
Context: {
    "cookiecutter": {
        "_template": "https://github.com/pretalx/pretalx-plugin-cookiecutter",
        "author_email": "test",
        "author_name": "test",
        "human_name": "test",
        "module_name": "test",
        "repo_name": "test",
        "repo_url": "test",
        "short_description": "test",
        "year": "test"
    }
}
```
